### PR TITLE
Fix async task scheduling during startup

### DIFF
--- a/main.py
+++ b/main.py
@@ -108,13 +108,20 @@ def main() -> None:
         logger.error("Telegram credentials missing")
         return
 
-    app = Application.builder().token(TELEGRAM_TOKEN).build()
+    async def start_tasks(application: Application) -> None:
+        """Create background tasks once the event loop is running."""
+        application.create_task(poll_whales(application))
+        application.create_task(refresh_wallets(application))
+
+    app = (
+        Application.builder()
+        .token(TELEGRAM_TOKEN)
+        .post_init(start_tasks)
+        .build()
+    )
+
     app.add_handler(CommandHandler("clone", clone))
     app.add_handler(CommandHandler("unclone", unclone))
-
-    # Schedule background tasks for polling and wallet discovery
-    app.create_task(poll_whales(app))
-    app.create_task(refresh_wallets(app))
 
     app.run_polling()
 


### PR DESCRIPTION
## Summary
- ensure background tasks are scheduled after the event loop is initialized

## Testing
- `python -m py_compile main.py wallet_discovery.py monitors/*.py storage.py`

------
https://chatgpt.com/codex/tasks/task_e_68603dc31790832e95c91ea85f056c11